### PR TITLE
French translation

### DIFF
--- a/source/jugglinglab/util/JLLocale.java
+++ b/source/jugglinglab/util/JLLocale.java
@@ -38,7 +38,15 @@ public class JLLocale {
         if (!(bundle instanceof PropertyResourceBundle))
             return bundle;
 
-        return new Utf8PropertyResourceBundle((PropertyResourceBundle)bundle);
+        // RA: it seems that the default encoding of resources files is now UTF-8
+        //          -> no need to convert it internaly anymore ??
+        //          -> this works for French translation at least,
+        //             as the GUIStrings_fr.properties file seems
+        //             to be encoded in UTF-8
+        //          -> others translations not checked
+        // TODO: add an encoding check to decide if we should go through Utf8PropertyResourceBundle
+        return bundle;
+        //return new Utf8PropertyResourceBundle((PropertyResourceBundle)bundle);
     }
 
     private static class Utf8PropertyResourceBundle extends ResourceBundle {

--- a/source/resources/GUIStrings_fr.properties
+++ b/source/resources/GUIStrings_fr.properties
@@ -5,9 +5,9 @@
 #
 # Language for this file = French (France)
 #
-Processing = processing...*
+Processing = traitements en cours...
 Click_Edit = Click Edit to create pattern*
-Edit = Edit*
+Edit = Edition*
 Pattern_entry = Edition
 Defaults = Restaurer
 Juggle = Jongler
@@ -29,22 +29,22 @@ synch = synchrone
 Compositions = Composés
 all = Tous
 non-obvious = Non évidents
-none_(prime_only) = premiers seulement
+none_(prime_only) = Premiers seulement
 Find = Trouver
 ground_state_patterns = figures fondamentales
 excited_state_patterns = figures excitées
 transition_throws = lancers de transitions
 pattern_rotations = permutations circulaires
-juggler_permutations = juggler permutations*
-connected_patterns = connected patterns only*
+juggler_permutations = permutations jongleurs
+connected_patterns = au moins une passe
 Multiplexing = Multiplex
 enable = activer
 simultaneous_throws = lancers simultanés
 no_simultaneous_catches = pas de récéptions simultanées
 no_clustered_throws = pas de lancers en grappe
-true_multiplexing = true multiplexing only*
-Exclude_these_throws = Exclure ces expressions*
-Include_these_throws = Inclure ces expressions*
+true_multiplexing = vrai multiplex uniquement
+Exclude_these_throws = Exclure ces expressions
+Include_these_throws = Inclure ces expressions
 Passing_communication_delay = Délai de communication (passing)
 File = Fichier
 Notation = Notation
@@ -54,30 +54,30 @@ New_Pattern_List = Nouvelle liste de figures
 Open_JML... = Ouvrir JML...
 Quit = Quitter
 About_Juggling_Lab = A propos de Juggling Lab
-Juggling_Lab_Online_Help = Juggling Lab Online Help
+Juggling_Lab_Online_Help = Aide en ligne de Juggling Lab
 Close = Fermer
 Save_JML_As... = Enregistrer JML sous...
 Save_Text_As... = Enregistrer texte sous...
 Patterns = Figures
 View = Voir
 Save_Animated_GIF_As... = Enregistrer le gif animé sous...
-Duplicate = Duplicate*
+Duplicate = Dupliquer
 Restart = Redémarrer
 Animation_Preferences... = Préférences d'animation...
-Simple = Simple*
+Simple = Simple
 Visual_editor = Editeur visuel
 Selection_editor = Editeur de sélection
 JML_editor = Editeur JML
 Animation_Preferences = Préférences d'animation
 Solid_3D_display = Affichage 3D pleine
 Width = Largeur
-Height = La taille
+Height = Hauteur
 Frames_per_second = Images par secondes
 Slowdown_factor = Facteur de ralentissement
 Border_(pixels) = Bordure (pixels)
 Double-buffered_animation = animation avec mémoire tampon doublée
 Start_paused = Redémarrer
-Pause_on_mouse_away = Pause on mouse away*
+Pause_on_mouse_away = Pause à la sortie de la souris
 Stereo_display = Affichage Stereo
 Catch_sounds = Réceptions sonores
 Bounce_sounds = Rebonds sonores
@@ -103,7 +103,7 @@ Throw_type = Type de lancer
 Message_click_to_start = Cliquer pour commencer
 Saving_animated_GIF = GIF animé en cours de sauvegarde
 Message_GIFsave_color_map = Construction de la table des couleurs
-Message_GIFsave_writing_frame = Ecriture de la frame
+Message_GIFsave_writing_frame = Ecriture du cadre
 JMLView_compile_button = Compiler
 JMLView_revert_button = Restaurer
 Pattern_List = Liste des figures
@@ -132,85 +132,85 @@ Generator_intro = Ceci est le générateur de siteswap de Juggling Lab, dérivé
     -no imprime juste les nombres         nombre donné de lancers simultanés\n \
     -g  figures fondamentales     -mf permet les réceptions multiples\n \
     -ng figures excitées          -mc empêche les lancers multiplex par lots\n \
-    -f  liste complète (avec      -mt  true multiplexing patterns*\n       \
+    -f  liste complète (avec      -mt  vrai multiplex uniquement\n       \
        les figures composées)     -d <nombre> retard de communication (passing)\n \
     -se disable starting/ending   -l <nombre>  passing leader person number\n \
     -prime premiers seulement     -x <lancer> ..  exclure les lancers pour soi\n \
     -rot avec permutations        -i <lancer> ..  inclure les lancers pour soi\n       \
         des figures               -lame supprimer les '11' en mode asynchrone\n \
-    -cp connected patterns only   -jp  show all juggler permutations*
-CLI_help1 = This is the command line interface to Juggling Lab. Recognized options:\n\n   \
+    -cp au moins une passe        -jp  affiche toutes les permutations de jongleurs
+CLI_help1 = Interface en ligne de commande de Juggling Lab. Options reconnues :\n\n   \
    jlab start\n\n      \
-      Launches the application.\n\n   \
+      Lancer l'application.\n\n   \
    jlab anim <pattern> [<prefs>]\n\n      \
-      Opens a window with an animation of the given pattern, using the\n      \
-      given (optional) animation preferences.\n\n   \
+      Ouvre une fenêtre avec l'animation du pattern, utilise le\n      \
+      fichier de préference (optionnel).\n\n   \
    jlab gen <gen_options> [-out <path>]\n\n      \
-      Runs the siteswap generator and prints a list of patterns, using the\n      \
-      given set of generator options to define the number of objects, etc.\n      \
-      Type "jlab gen" with no options for a help message. The output may\n      \
-      optionally be written to a file.\n\n   \
+      Lance le générateur de siteswap et affiche la liste des figures, en\n      \
+      utilisant les options du générateur pour définir le nombre d'objects, etc...\n      \
+      Tapez "jlab gen" sans option pour afficher un message d'aide. La sortie peut\n      \
+      être écrite dans un fichier.\n\n   \
    jlab togif <pattern> [<prefs>] -out <path>\n\n      \
-      Saves a pattern animation to a file as an animated GIF, using the\n      \
-      given (optional) animation preferences.\n\n   \
+      Sauvegarde la figure animée au fomrat GIF animé, en utilisant les options\n      \
+      d'animations (optionnel).\n\n   \
    jlab tojml <pattern> [-out <path>]\n\n      \
-      Converts a pattern to JML notation, Juggling Lab's internal XML-based\n      \
-      pattern description. This may optionally be written to a file.\n\n\
-Pattern input:\n\n   \
-   <pattern> can take one of three formats:\n\n   \
-   1. A pattern in siteswap notation, for example 771 or (6x,4)(4,6x).\n   \
-   2. A siteswap pattern annotated with additional settings, in a semi-\n      \
-      colon separated format. This is described in more detail at\n      \
+      Convertit un pattern dans la notation JML, le format interne de Juggling Lab\n      \
+      basé en XML. Peut être sauvegardé dans un fichier (optionnel).\n\n\
+Entrées pattern:\n\n   \
+   <pattern> peut prendre un des trois formats suivants :\n\n   \
+   1. Un pattern en notation siteswap, par exemple 771 ou (6x,4)(4,6x).\n   \
+   2. Un siteswap annoté avec des paramètres additionels, séparés par des\n      \
+       points-virugles. Description plus détaillée sur la page\n      \
       https://jugglinglab.org/html/sspanel.html\n   \
-   3. A JML pattern read in from a file, using the format '-jml <path>'.\n\n\
-Animation preferences input:\n\n   \
-   <prefs> are optional wherever they are used, and are used to override\n   \
-   Juggling Lab's default preferences. These are given in a semicolon-\n   \
-   separated format. See https://jugglinglab.org/html/animinfo.html\n\n\
-NOTE: These settings may contain characters that are interpreted in special\n\
-ways by command line interpreters. On Windows use double quotes around\n\
-settings to avoid confusion, and single quotes on Mac OS X/Unix.\n\n
-CLI_help2 = Examples:\n\n   \
+   3. Un pattern JML lu depuis un fichier, utilisant le format '-jml <path>'.\n\n\
+Options d'animation:\n\n   \
+   Les options d'animations <prefs> sont optionnelles. Si spécifiées, elles remplacent\n   \
+   les options par défault de Juggling Lab. Elles doivent être séparées par des\n \
+   points virgules. Voir https://jugglinglab.org/html/animinfo.html\n\n\
+NOTE: Ces réglages peuvent contenir des caractères qui sont mal interprétés par le\n \
+terminal. Sur Windows utilisez des doubles guillements autour des options pour éviter\n \
+une mauvaise interprétation. Sur Mac OS X/Unix, utilisez des guillemets simples.\n\n
+CLI_help2 = Exemples:\n\n   \
       jlab anim '(6x,4)*'\n   \
       jlab togif 'pattern=3;dwell=1.0;bps=4.0;hands=(-30)(2.5).(30)(-2.5).(-30)(0).' -out mills.gif\n   \
       jlab anim -jml my_favorite_pattern.jml\n   \
       jlab anim 771 -prefs 'stereo=true;width=800;height=600'\n   \
       jlab anim 5B -prefs 'bouncesound=true'\n   \
       jlab gen 5 7 5\n
-Prop_name_ball = ball
-Prop_name_ring = ring
+Prop_name_ball = balle
+Prop_name_ring = anneau
 Prop_name_image = image
 MHNHands_name_default = défaut
-MHNHands_name_inside = inside throws
-MHNHands_name_outside = outside throws
-MHNHands_name_half = half shower
+MHNHands_name_inside = cascade
+MHNHands_name_outside = cascade inversée
+MHNHands_name_half = demi douche
 MHNHands_name_Mills = Mills Mess
 MHNHands_name_custom = personnalisé
 MHNBody_name_default = défaut
-MHNBody_name_line = line
-MHNBody_name_feed = feed
-MHNBody_name_backtoback = back to back
-MHNBody_name_sidetoside = side to side
-MHNBody_name_circles = circles
+MHNBody_name_line = ligne
+MHNBody_name_feed = poste
+MHNBody_name_backtoback = dos à dos
+MHNBody_name_sidetoside = côte à côte
+MHNBody_name_circles = cercles
 MHNBody_name_custom = personnalisé
-New_version_available = New Version Available
-New_version_text1 = Version {0} of Juggling Lab is available for
-New_version_text2 = download. You are currently running version {0}.
-New_version_text3 = Would you like to visit the download site?
-Update_cancel = Cancel
-Update_yes = Yes
-Download_message = Please visit {0} to download.
-Mutator_header1 = Mutation Types
-Mutator_type1 = Change event positions
-Mutator_type2 = Change event times
-Mutator_type3 = Adjust overall timing
-Mutator_type4 = Add new events
-Mutator_type5 = Remove events
-Mutator_header2 = Mutation Rate
-Mutation_rate_low = Low
-Mutation_rate_medium = Medium
-Mutation_rate_high = High
-Prefs_show_ground = Show ground
+New_version_available = Nouvelle Version Disponible
+New_version_text1 = La version {0} de Juggling Lab est téléchargeable.
+New_version_text2 = Vous utilisez actuellement la version {0}.
+New_version_text3 = Voulez-vous visitez le site de téléchargment ?
+Update_cancel = Annuler
+Update_yes = Oui
+Download_message = Visitez {0} pour télécharger.
+Mutator_header1 = Types de mutations
+Mutator_type1 = Change la position des évènements
+Mutator_type2 = Change le temps des évènements
+Mutator_type3 = Ajuste le timing global
+Mutator_type4 = Ajoute de nouveaux évènements
+Mutator_type5 = Supprime des évènements
+Mutator_header2 = Taux de mutation
+Mutation_rate_low = faible
+Mutation_rate_medium = moyen
+Mutation_rate_high = fort
+Prefs_show_ground = Affiche le sol
 Prefs_show_ground_auto = auto
-Prefs_show_ground_yes = yes
-Prefs_show_ground_no = no
+Prefs_show_ground_yes = oui
+Prefs_show_ground_no = non


### PR DESCRIPTION
Hi Jack !

Here is an update of the french translation. I have only one doubt about "_connected patterns only_". Does that mean "_at least one pass between jugglers_" ? This is how I have translated it anyway.

Also I have deactivated the ISO-8859-1 to UTF-8 conversion. I believe this was here because resource files were using ISO-8859-1 encoding, which is not the case anymore. At least on my computer. So to have a proper display of special french characters, I had to disable it. There might be a cleaner way to do that. You'll tell me.

Roman
