### PR TITLE
hand siteswap feature for Juggling Lab

### DIFF
--- a/source/jugglinglab/notation/HSS.java
+++ b/source/jugglinglab/notation/HSS.java
@@ -1,0 +1,644 @@
+package jugglinglab.notation;
+
+import java.text.MessageFormat;
+import java.util.*;
+
+import jugglinglab.util.*;
+
+class hssParms {
+	ArrayList<Character> pat;
+	int hands;
+}
+
+class patParms {
+//	int[][] beatJugHndMap;
+	String newPat;
+	double[] dwellBt;
+}
+
+class modParms {
+	String convertedPattern;
+	double[] dwellBeatsArray;
+}
+
+public class HSS {
+    static final ResourceBundle guistrings = jugglinglab.JugglingLab.guistrings;
+    static final ResourceBundle errorstrings = jugglinglab.JugglingLab.errorstrings;
+    
+    public static modParms processHSS(String p, String h, boolean hld, boolean dwlmax, String hndspc, double dwl) throws 
+                                 JuggleExceptionUser, JuggleExceptionInternal {
+    	int ossPer, hssPer, hssOrb, patPer, numHnd, numJug;
+    	String convPat;
+    	double[] dwellArr;
+    	modParms modinf = new modParms();
+    		  
+	    ArrayList<ArrayList<Character>> ossPat = new ArrayList<ArrayList<Character>>();
+	    ArrayList<Character> hssPat = new ArrayList<Character>();
+	    hssParms hssinfo;
+	    patParms patinfo;
+	    
+	    ossPat = OssSyntax(p);
+	    
+	    hssinfo = HssSyntax(h);
+	    
+        hssPat = hssinfo.pat;
+        numHnd = hssinfo.hands;
+	    ossPer = ossPat.size();
+	    hssPer = hssPat.size();
+	    
+	    ossPerm(ossPat, ossPer);
+	    
+	    hssOrb = hssPerm(hssPat, hssPer);
+	    
+	    int[][] handmap = new int[numHnd][2];//size not required here?
+	    
+	    if (hndspc != null) {
+	    	handmap = parsehandspec(hndspc,numHnd);
+	    } else {
+	    	handmap = defhandspec(numHnd);
+	    }
+	    
+	    numJug = 1;
+	    for (int i = 0; i < numHnd; i++) {
+	    	if (handmap[i][0] > numJug) {
+	    		numJug = handmap[i][0];
+	    	}
+	    }
+	    
+	    //recalculate ossPer, hssPer inside convNotation itself; even numJug??
+	    patinfo = convNotation(ossPat, hssPat, ossPer, hssPer, hssOrb, handmap, numJug, hld, dwlmax, dwl);		
+    	modinf.convertedPattern = patinfo.newPat;
+//	    convPat = patinfo.newPat;
+	    if (modinf.convertedPattern == null) {
+	    	throw new JuggleExceptionUser("no pattern");
+	    }
+	    
+	    modinf.dwellBeatsArray = patinfo.dwellBt;
+	    return modinf;
+    }   
+    
+    // check object pattern for syntax and average test
+    public static ArrayList<ArrayList<Character>> OssSyntax(String ss) throws 
+                             JuggleExceptionUser, JuggleExceptionInternal{
+    	boolean pass = true;
+	    boolean muxThrow = false;
+	    boolean muxThrowFound = false;
+	    boolean minOneThrow = false;
+	    int throwSum = 0;
+	    int numBeats = 0;
+	    int subBeats = 0;
+	    int numObj = 0;
+	    ArrayList<ArrayList<Character>> oPat = new ArrayList<ArrayList<Character>>();
+        for (int i = 0; i < ss.length(); i++) {
+    	    char c = ss.charAt(i);
+    	    if (muxThrow) {
+    		    if (Character.toString(c).matches("[0-9,a-z]")) {
+    			    minOneThrow = true;
+    			    muxThrowFound = true;
+                    oPat.get(numBeats-1).add(subBeats, c);
+    			    subBeats++;
+   				    throwSum += Character.getNumericValue(c);
+    			    continue;
+    		    } else if (c == ']') {
+    			    if (muxThrowFound) {
+    				    muxThrow = false;
+    				    muxThrowFound = false;
+    				    subBeats = 0;
+    				    continue;
+    			    } else {
+    				    pass = false;
+    				    break;
+    			    }
+    		    } else if (c == '\s') {
+    			    continue;
+    		    } else {
+    			    pass = false;
+    			    break;
+    		    }
+    	    } else {
+    		    if (Character.toString(c).matches("[0-9,a-z]")) {
+    			    minOneThrow = true;
+                    oPat.add(numBeats, new ArrayList<Character>());
+                    oPat.get(numBeats).add(subBeats, c);
+    			    numBeats++;
+   				    throwSum += Character.getNumericValue(c);
+    			    continue;
+    		    } else if (c == '[') {
+    			    muxThrow = true;
+                    oPat.add(numBeats, new ArrayList<Character>());
+    			    numBeats++;
+    			    continue;
+    		    } else if (c == '\s') {
+    			    continue;
+    		    } else {
+    			    pass = false;
+    			    break;
+    		    }
+    	    } // if-else muxThrow
+        } //for
+        if (!muxThrow && minOneThrow && pass) {
+    	    if (throwSum%numBeats == 0) {
+    		    numObj = throwSum/numBeats;
+    		    pass = true;
+    	    } else {
+    		    pass = false;
+    	    }
+        } else {
+    	    pass = false;
+        }
+	    if (!pass) {
+		    throw new JuggleExceptionUser("Invalid syntax or average for object pattern");
+	    }
+        return oPat;  
+      } //OssSyntax
+
+    // check hand pattern for syntax and average test
+      public static hssParms HssSyntax(String ss) throws 
+                          JuggleExceptionUser, JuggleExceptionInternal{
+    	  
+    	  int throwSum = 0;
+	      int numBeats = 0;
+	      int nh = 0;
+	      boolean pass = true;
+	      ArrayList<Character> hPat = new ArrayList<Character>();
+          for (int i = 0; i < ss.length(); i++) {
+    	      char c = ss.charAt(i);
+		      if (Character.toString(c).matches("[0-9,a-z]")) {
+                  hPat.add(numBeats, c);
+			      numBeats++;
+			      throwSum += Character.getNumericValue(c);
+			      continue;
+		      } else if (c == '\s') {
+			      continue;
+		      } else {
+			      pass = false;
+			      break;
+		      }
+          }	
+          if (pass) {
+    	      if (throwSum%numBeats == 0) {
+    		      nh = throwSum/numBeats;
+    		      pass = true;
+    	      } else {
+    		      pass = false;
+    	      }
+          }
+          if (!pass) {
+		      throw new JuggleExceptionUser("Invalid syntax or average for hand pattern");
+	      }
+
+          hssParms hssinf = new hssParms();
+	      hssinf.pat = hPat;
+	      hssinf.hands = nh;
+	      
+          return hssinf;  
+      }
+      
+      // permutation test for object pattern
+      public static void ossPerm(ArrayList<ArrayList<Character>> os, int op) throws 
+                                            JuggleExceptionUser, JuggleExceptionInternal {
+	      boolean pass = true;
+		  ArrayList<ArrayList<Integer>> mods = new ArrayList<ArrayList<Integer>>();
+	      int m;
+	      int[] cmp = new int[op];
+	      for (int i = 0; i < op; i++) {
+	    	  mods.add(i, new ArrayList<Integer>());
+	    	  for (int j = 0; j < os.get(i).size(); j++) {
+	    		  m = (Character.getNumericValue(os.get(i).get(j)) + i) % op;
+	    		  mods.get(i).add(j,m);
+	    		  cmp[m]++;
+	    	  }
+	      }
+	      
+	      for (int i = 0; i < op; i++) {
+    		  if (cmp[i] != os.get(i).size()) {
+    			  pass = false;
+	    	  }
+	      }
+	      if (!pass) {
+	    	  throw new JuggleExceptionUser("object pattern is invalid");
+	      }
+      }
+
+      // permutation test for hand pattern, return longest hand orbit
+      public static int hssPerm(ArrayList<Character> hs, int hp) throws 
+                                         JuggleExceptionUser, JuggleExceptionInternal{
+	      boolean pass = true;
+	      int m, ho;
+		  int[] mods = new int[hp];
+	      int[] cmp = new int[hp];
+	      int[] orb = new int[hp];
+	      boolean[] touched = new boolean[hp];
+	      for (int i = 0; i < hp; i++) {
+    		  m = (Character.getNumericValue(hs.get(i)) + i) % hp;
+    		  mods[i] = m;
+    		  cmp[m]++;
+	      }
+	      
+	      for (int i = 0; i < hp; i++) {
+    		  if (cmp[i] != 1) {
+    			  pass = false;
+	    	  }
+	      }
+	      ho = 0;
+	      if (pass) {
+	    	  for (int i = 0; i < hp; i++) {
+	    		  if (!touched[i]) {
+	    			  int j = i;
+	    			  orb[i] = Character.getNumericValue(hs.get(i));
+	    			  touched[i] = true;
+	    			  j = mods[i];
+	    			  while (j != i) {
+	    				  orb[i] += Character.getNumericValue(hs.get(j));
+	    				  touched[j] = true;
+		    			  j = mods[j];
+	    			  }
+	    		  }
+	    		  if (orb[i] > ho) {
+	    			  ho = orb[i];
+	    		  }
+	    	  }
+	      } else {
+	    	  throw new JuggleExceptionUser("hand pattern is invalid");
+	      }
+	      return ho;  
+      }
+
+      public static int[][] parsehandspec(String hs, int nh) throws 
+                                             JuggleExceptionUser, JuggleExceptionInternal{
+
+    	  int[][] hm = new int[nh][2];
+    	  //assigningLefthand, assigningRighthand, jugglerActive
+    	  boolean al = false;
+    	  boolean ar = false;
+    	  boolean ja = false;
+    	  boolean pass = false;
+    	  boolean hp = false; //handPresent
+    	  boolean ns = false; //numberformationStarted
+    	  boolean mf = false; //matchFound
+    	  int jn = 0; //jugglerNumber
+    	  String bhn = null; //buildHandNumber
+    	  
+    	  for (int i = 0; i < hs.length(); i++) {
+    		  char c = hs.charAt(i);
+    		  if (!ja) {
+    			  if (c == '(') {
+    				  ja = true;
+    				  al = true;
+    				  ns = true;
+    				  bhn = null;
+    				  pass = false;
+    				  hp = false;
+    				  jn++;
+    				  continue;
+    			  } else if (c == '\s') {
+    				  continue;
+    			  } else {
+    				  throw new JuggleExceptionUser("error in handspec syntax");
+    			  }
+    		  } else {
+    			  if (al) {
+    				  if (Character.toString(c).matches("[0-9]")) {
+    					  if (ns) {
+        				      if (bhn == null) {
+        				    	  bhn = Character.toString(c);
+        				      } else {
+        				    	  bhn = bhn + Character.toString(c);
+        				      }
+        				      continue;
+    					  } else {
+    						  throw new JuggleExceptionUser("error in handspec syntax"); 
+    					  }
+        			  } else if (c == '\s') {
+        				  if ((bhn != null) && (bhn.length() >= 1)) {
+        					  ns = false;
+        					  continue;
+        				  } else {
+        					  continue;
+        				  }
+        			  } else if (c == ',') {
+        				  al = false;
+        				  ar = true;
+        				  ns = true;
+ 
+        				  if (bhn != null) {
+        					  if ((Integer.parseInt(bhn) >= 1) &&(Integer.parseInt(bhn) <= nh)) {
+        						  hm[Integer.parseInt(bhn)-1][0] = jn;
+            					  hm[Integer.parseInt(bhn)-1][1] = 0;
+            					  hp = true;
+        					  } else {
+        						  throw new JuggleExceptionUser("hand number out of range in handspec"); 
+        					  }
+        				  } else {
+        					  hp = false;
+        				  }
+        				  bhn = null;
+        				  continue;
+        			  } else {
+        				  throw new JuggleExceptionUser("error in handspec syntax");
+        			  }
+    			  } else if (ar) {
+        			  if (Character.toString(c).matches("[0-9]")) {
+    					  if (ns) {
+        				      if (bhn == null) {
+        				    	  bhn = Character.toString(c);
+        				      } else {
+        				    	  bhn = bhn + Character.toString(c);
+        				      }
+        				      continue;
+    					  } else {
+    						  throw new JuggleExceptionUser("error in handspec syntax"); 
+    					  }
+        			  } else if (c == '\s') {
+        				  if ((bhn != null) && (bhn.length() >= 1)) {
+        					  ns = false;
+        					  continue;
+        				  } else {
+        					  continue;
+        				  }
+        			  } else if (c == ')') {
+        				  ar = false;
+        				  ja = false;
+
+        				  if (bhn != null) {
+        					  if ((Integer.parseInt(bhn) >= 1) &&(Integer.parseInt(bhn) <= nh)) {
+        						  hm[Integer.parseInt(bhn)-1][0] = jn;
+            					  hm[Integer.parseInt(bhn)-1][1] = 1;
+        					  } else {
+        						  throw new JuggleExceptionUser("hand number out of range in handspec"); 
+        					  }
+        				  } else if (!hp) {
+        					  throw new JuggleExceptionUser("specify at least one hand for each juggler");
+        				  }
+        				  bhn = null;
+        				  pass = true;
+        				  continue;
+        			  } else {
+        				  throw new JuggleExceptionUser("error in handspec syntax");
+        			  }
+   				  
+    			  }
+    			  
+    		  }
+    		  
+    	  }
+    	  if (jn > nh) {
+    		  throw new JuggleExceptionUser("error in handspec, too many jugglers");
+    	  }
+    	  if (pass) {
+    		  for (int i = 0; i < nh; i++) {
+				  if (hm[i][0] != 0) {
+					  mf = true;
+					  break;
+				  }
+    			  if (!mf) {
+    				  throw new JuggleExceptionUser("hands missing in handspec");
+    			  }
+    		  }
+    	  } else {
+    		  throw new JuggleExceptionUser("error in handspec syntax");
+    	  }
+    	  
+    	  for (int i = 0; i < nh; i++) {
+    		  if (hm[i][0] == 0) {
+    			  throw new JuggleExceptionUser("juggler not assigned to hand " +(i+1));
+    		  }
+    	  }
+    	  return hm;
+      }
+
+      public static int[][] defhandspec(int nh) throws 
+                                  JuggleExceptionUser, JuggleExceptionInternal{
+
+    	  int[][] hm = new int[nh][2];
+    	  int nj; //numberofJugglers
+    	  
+    	  if (nh%2==0) {
+    		  nj = nh/2;
+    	  } else {
+    		  nj = (nh+1)/2;
+    	  }
+    	  
+    	  for (int i = 0; i < nh; i++) {
+    		  if (i < nj) {
+    			  hm[i][0] = i+1; // juggler number
+        		  hm[i][1] = 1; // 0 for left hand, 1 for right
+    		  } else {
+    			  hm[i][0] = i+1 - nj;
+    			  hm[i][1] = 0;
+    		  }
+    	  }
+    	  
+    	  return hm;
+      }
+
+      public static patParms convNotation(ArrayList<ArrayList<Character>> os, 
+    		                       ArrayList<Character> hs, int op, int hp, 
+    		                       int ho, int[][] hm, int nj, boolean h, boolean dm, double dd) throws 
+                                      JuggleExceptionUser, JuggleExceptionInternal{
+	      int pp, ch, t, cj; //pattern period, current hand, throw, current juggler
+    	  String cp = null;  //converted pattern
+          patParms patinf = new patParms();
+          boolean flag = false;
+	      
+    	//invert, pass and hold for x, p and H
+    	  ArrayList<ArrayList<String>> iph = new ArrayList<ArrayList<String>>(); 
+	      
+		  pp = Permutation.lcm(op, ho); //pattern period
+		  
+		  int[] ah = new int[pp]; //assigned hand
+		  boolean ad[] = new boolean[pp]; //assignment done
+	      int[][] ji = new int[pp][2]; //jugglerInfo: juggler#, hand#
+	      double[] db= new double[pp]; //dwell beats
+	      
+	      //extend oss to lcm(ossPer, hssOrb)
+	      if (pp > op) {
+	    	  for (int i = op; i < pp; i++) {
+	    		  os.add(i,os.get(i-op));
+//	    		  os.add(i, new ArrayList<Character>());
+//	    		  for (int j = 0; j < os.get(i-op).size(); j++) {
+//	    			  os.get(i).add(j, os.get(i-op).get(j));
+//	    		  }
+	    	  }
+	      }
+	      
+	      //extend hss to lcm(ossPer, hssOrb)
+	      if (pp > hp) {
+	    	  for (int i = hp; i < pp; i++) {
+	    		  hs.add(i, hs.get(i-hp));
+	    	  }
+	      }
+	      
+	      //check if hss is 0 when oss is not 0; else assign juggler and hand to each beat
+	      ch = 0;
+	      for (int i = 0; i < pp; i++) {
+	    	  if (hs.get(i) == '0') {
+	    		  for (int j = 0; j < os.get(i).size(); j++) {
+	    			  if (os.get(i).get(j) != '0') {
+	    				  throw new JuggleExceptionUser("no hand to throw object at beat " +(i+1));
+	    			  }
+	    		  }
+	    	  } 
+	    	  if (!ad[i]) {
+	    		  ch++;
+	    		  ah[i] = ch;
+	    		  ad[i] = true;
+	    		  int next = (i + Character.getNumericValue(hs.get(i)))%pp;
+	    		  while (next != i) {
+	    			  ah[next] = ch;
+	    			  ad[next] = true;
+	    			  next = (next + Character.getNumericValue(hs.get(next)))%pp;
+	    		  }
+	    	  }
+	    	  ji[i][0] = hm[ah[i]-1][0]; //juggler number at beat i
+	    	  ji[i][1] = hm[ah[i]-1][1]; //throwing hand at beat i
+	      }
+//	      patinf.beatJugHndMap = ji;
+	      
+	      //determine dwellbeats array
+	      flag = false;
+	      if (!dm) {
+	    	  for (int i = 0; i < pp; i++) {
+	    		  if ((ji[i][0] == ji[(i+1)%pp][0]) && (ji[i][1] == ji[(i+1)%pp][1])) {
+	    			  flag = true; //if same hand throws on successive beats
+	    			  break;
+	    		  }
+	    	  }
+	    	  if (flag) {
+	    		  for (int i = 0; i < pp; i++) {
+	    			  db[i] = 0.3;
+	    		  }
+	    	  } else {
+	    		  for (int i = 0; i < pp; i++) {
+	    			  db[i] = dd; //user defined default dwell in front panel
+	    		  }	  
+	    	  }
+	      } else {//if dwellmax is true
+	    	  for (int i = 0; i < pp; i++) {
+	    		  int j = (i+1)%pp;
+	    		  int diff = 1;
+	    		  while ((ji[i][0] != ji[j][0]) || (ji[i][1] != ji[j][1])) {
+	    			  j = (j+1)%pp;
+	    			  diff++;
+	    		  }
+	    		  db[j] = diff - 0.7;
+	    	  }
+	      }
+	      patinf.dwellBt = db;
+	      //determine x, p and H throws
+	      for (int i = 0; i < pp; i++) {
+	    	  iph.add(i, new ArrayList<String>());
+	    	  for (int j = 0; j < os.get(i).size(); j++) {
+		    	  iph.get(i).add(j, null);
+		    	  t = Character.getNumericValue(os.get(i).get(j));
+	    		  if (t%2 == 0 && ji[i][1] != ji[(i+t)%pp][1]) {
+	    			  iph.get(i).set(j,"x"); //put x for even throws to other hand
+	    		  } else if (t%2 != 0 && ji[i][1] == ji[(i+t)%pp][1]) {
+	    			  iph.get(i).set(j,"x"); //put x for odd throws to same hand
+	    		  }
+	    		  if (ji[i][0] != ji[(i+t)%pp][0]) {
+	    			  if (iph.get(i).get(j) != "x") {
+	    				  iph.get(i).set(j,"p"+ji[(i+t)%pp][0]+"\s");
+	    			  } else {
+	    				  iph.get(i).set(j,"xp"+ji[(i+t)%pp][0]+"\s");
+	    			  }
+	    		  } else if (h) {
+	    			  if (t == Character.getNumericValue(hs.get(i))) {
+	    				  if (iph.get(i).get(j) != "x") {
+	    					  iph.get(i).set(j,"H");
+	    				  } else {
+	    					  iph.get(i).set(j,"xH");
+	    				  }
+	    			  }
+	    		  }
+	    	  }
+
+	      }
+	      
+	      
+	      //construct the pattern string
+	      for (int i = 0; i < pp; i++) {
+	    	  cj = 0;
+	    	  while (cj < nj) {
+	    		  if (cp == null) {
+	    			  cp = "<";
+	    		  } else if (cj == 0){
+	    			  cp = cp + "<";
+	    		  }
+	    		  if (ji[i][1] == 0) {//if left hand is throwing at current beat
+	    			  cp = cp + "(";
+	    			  if (ji[i][0] == cj+1) {//if currentjuggler is throwing at current beat
+	    				  if (os.get(i).size() > 1) {// if it is a multiplex throw
+	    					  cp = cp + "[";
+	    					  for (int j = 0; j < os.get(i).size(); j++) {
+	    						  cp = cp + Character.toString(os.get(i).get(j));
+	    						  if (iph.get(i).get(j) != null) {
+	    							  cp = cp + iph.get(i).get(j);
+	    						  }
+	    					  }
+	    					  cp = cp + "]";
+	    				  } else {// if not multiplex throw
+	    					  cp = cp + Character.toString(os.get(i).get(0));
+	    					  if (iph.get(i).get(0) != null) {
+	    						  cp = cp + iph.get(i).get(0);
+	    					  }
+	    				  }
+	    				  cp = cp + ",0)!"; //no sync throws allowed, put 0 for right hand
+	    				  if (cj == nj-1) {
+	    					  cp = cp + ">";
+	    				  } else {
+	    					  cp = cp + "|";
+	    				  }
+	    				  cj++;
+	    			  } else {// if current juggler is not throwing at this beat
+	    				  cp = cp + "0,0)!";
+	    				  if (cj == nj-1) {
+	    					  cp = cp + ">";
+	    				  } else {
+	    					  cp = cp + "|";
+	    				  }
+	    				  cj++;
+	    			  }
+	    		  } else {// if right hand is throwing at this beat
+	    			  cp = cp + "(0,";
+	    			  if (ji[i][0] == cj+1) {//if currentjuggler is throwing at current beat
+	    				  if (os.get(i).size() > 1) {// if it is a multiplex throw
+	    					  cp = cp + "[";
+	    					  for (int j = 0; j < os.get(i).size(); j++) {
+	    						  cp = cp + Character.toString(os.get(i).get(j));
+	    						  if (iph.get(i).get(j) != null) {
+	    							  cp = cp + iph.get(i).get(j);
+	    						  }
+	    					  }
+	    					  cp = cp + "]";
+	    				  } else {// if not multiplex throw
+	    					  cp = cp + Character.toString(os.get(i).get(0));
+	    					  if (iph.get(i).get(0) != null) {
+	    						  cp = cp + iph.get(i).get(0);
+	    					  }
+	    				  }
+	    				  cp = cp + ")!";
+	    				  if (cj == nj-1) {
+	    					  cp = cp + ">";
+	    				  } else {
+	    					  cp = cp + "|";
+	    				  }
+	    				  cj++;
+	    			  } else {// if current juggler is not throwing at this beat
+	    				  cp = cp + "0)!";
+	    				  if (cj == nj-1) {
+	    					  cp = cp + ">";
+	    				  } else {
+	    					  cp = cp + "|";
+	    				  }
+	    				  cj++;
+	    			  }
+	    		  } //if-else left-right hand
+	    	  } //while cj < nj
+	      } //for all beats
+	      
+	      patinf.newPat = cp;
+	      return patinf;  
+      } //convNotation
+
+}

--- a/source/jugglinglab/notation/MHNPattern.java
+++ b/source/jugglinglab/notation/MHNPattern.java
@@ -34,10 +34,10 @@ public abstract class MHNPattern extends Pattern {
     protected static double propdiam_default = 10.0;
     protected static double bouncefrac_default = 0.9;
     protected static String prop_default = "ball";
-    //Mahit begin
+    //hss begin
     protected static boolean hold_default = false;
     protected static boolean dwellmax_default = true;
-    //Mahit end
+    //hss end
 
     // original config string:
     protected String config;
@@ -52,13 +52,13 @@ public abstract class MHNPattern extends Pattern {
     protected String prop = prop_default;
     protected String[] color;
     protected String title;
-    //Mahit begin
+    //hss begin
     protected String hss;  
     protected boolean hold = hold_default; 
     protected boolean dwellmax = dwellmax_default;
     protected String handspec;
     protected double[] dwellarray;
-    //Mahit end
+    //hss end
 
     // internal variables:
     protected int numjugglers;
@@ -183,7 +183,7 @@ public abstract class MHNPattern extends Pattern {
             }
         }
 
-//Mahit begin
+//hss begin
         if ((temp = pl.removeParameter("hss")) != null) {
             hss = temp;
         }
@@ -209,17 +209,17 @@ public abstract class MHNPattern extends Pattern {
                 handspec = temp;
             }
         }
-//Mahit end
+//hss end
         if ((temp = pl.removeParameter("title")) != null) {
             this.title = temp.trim();
         }
-//Mahit begin
+//hss begin
         if (hss != null) {
         	this.title = "oss: " + pattern + " ; hss: " + hss;
         }
         return this;
     }
-//Mahit end
+//hss end
 
     @Override
     public String toString() {
@@ -751,11 +751,14 @@ public abstract class MHNPattern extends Pattern {
         if (bps <= 0.0)       // signal that we should calculate bps
             bps = calcBps();
 
-//Mahit begin
+//hss begin
+//  code to modify bps according to number of jugglers
+//  and potentially the specific pattern being juggled
+//  can be inserted here for example:
 //        if (hss != null) {
 //        	bps *= result.getNumberOfJugglers();
 //        }
-//Mahit end
+//hss end
         
         int balls = getNumberOfPaths();
         int props = (color == null) ? 1 : Math.min(balls, color.length);
@@ -1021,14 +1024,14 @@ public abstract class MHNPattern extends Pattern {
                     else
                         throwtime = (double)k / bps;
 
-//Mahit begin
+//hss begin
                     if (hss != null) {
 //                    	if (onethrown)
 //                    		throwtime = ((double)k - 0.25*(double)dwellarray[k]) / bps;
 //                    	else
                     		throwtime = (double)k / bps;
                     }
-//Mahit end                        
+//hss end                        
                     
                     ev.setT(throwtime);
 
@@ -1120,7 +1123,7 @@ public abstract class MHNPattern extends Pattern {
                         else
                             lastcatchtime = ((double)k - dwell) / bps;
 
-//Mahit begin
+//hss begin
                         int newk = 0;
                         if (hss != null) {
                         	//if getPeriod() > size of dwellarray due to repeats
@@ -1134,7 +1137,7 @@ public abstract class MHNPattern extends Pattern {
 
                         	lastcatchtime = ((double)k - dwellarray[newk]) / bps;
                         }
-//Mahit end                        
+//hss end                        
                         ev.setT(lastcatchtime);
 
                         // set the event juggler and hand
@@ -1196,7 +1199,7 @@ public abstract class MHNPattern extends Pattern {
                                 else
                                     catchtime = ((double)k - dwell + ((double)sst2.catchnum/(double)(num_catches-1) - 0.5) *
                                                  splitcatchfactor) / bps;
-//Mahit begin
+//hss begin
                                 int newk;
                                 if (hss != null) {
                                 	//if getPeriod() > size of dwellarray due to repeats
@@ -1210,7 +1213,7 @@ public abstract class MHNPattern extends Pattern {
                                 	catchtime = ((double)k - dwellarray[newk] + ((double)sst2.catchnum/(double)(num_catches-1) - 0.5) *
                                             splitcatchfactor) / bps;
                                 }
-//Mahit end                        
+//hss end                        
                                 ev.setT(catchtime);
 
                                 if (sst.catchnum == (num_catches - 1))
@@ -1284,21 +1287,22 @@ public abstract class MHNPattern extends Pattern {
                                     nextcatchtime = ((double)tempk - 0.5*dwell) / bps;
                                 else
                                     nextcatchtime = ((double)tempk - dwell) / bps;
-//Mahit begin
+//hss begin
+// why do things work without modifying nextcatchtime logic?
                                 if (hss != null) {
 //                                	nextcatchtime = ((double)tempk - dwellarray[tempk]) / bps;
                                 }
-//Mahit end                        
+//hss end                        
                             } else {
                                 if (next_onecaught)
                                     nextcatchtime = ((double)tempk - 0.5*dwell - 0.5*splitcatchfactor) / bps;
                                 else
                                     nextcatchtime = ((double)tempk - dwell - 0.5*splitcatchfactor) / bps;
-//Mahit begin
+//hss begin
                                 if (hss != null) {
 //                                	nextcatchtime = ((double)tempk - dwellarray[tempk]  - 0.5*splitcatchfactor)  / bps;
                                 }
-//Mahit end                        
+//hss end                        
 
                             }
                             break;

--- a/source/jugglinglab/notation/MHNPattern.java
+++ b/source/jugglinglab/notation/MHNPattern.java
@@ -34,6 +34,10 @@ public abstract class MHNPattern extends Pattern {
     protected static double propdiam_default = 10.0;
     protected static double bouncefrac_default = 0.9;
     protected static String prop_default = "ball";
+    //Mahit begin
+    protected static boolean hold_default = false;
+    protected static boolean dwellmax_default = true;
+    //Mahit end
 
     // original config string:
     protected String config;
@@ -48,6 +52,13 @@ public abstract class MHNPattern extends Pattern {
     protected String prop = prop_default;
     protected String[] color;
     protected String title;
+    //Mahit begin
+    protected String hss;  
+    protected boolean hold = hold_default; 
+    protected boolean dwellmax = dwellmax_default;
+    protected String handspec;
+    protected double[] dwellarray;
+    //Mahit end
 
     // internal variables:
     protected int numjugglers;
@@ -172,6 +183,33 @@ public abstract class MHNPattern extends Pattern {
             }
         }
 
+//Mahit begin
+        if ((temp = pl.removeParameter("hss")) != null) {
+            hss = temp;
+        }
+
+        if (hss != null) {
+            if ((temp = pl.removeParameter("hold")) != null) {
+                try {
+                    hold = Boolean.parseBoolean(temp);
+                } catch (IllegalFormatException ife) {
+                    throw new JuggleExceptionUser("Please enter true/false for hold");
+                }
+            } 
+
+            if ((temp = pl.removeParameter("dwellmax")) != null) {
+                try {
+                    dwellmax = Boolean.parseBoolean(temp);
+                } catch (IllegalFormatException ife) {
+                    throw new JuggleExceptionUser("Please enter true/false for dwellmax");
+                }
+            }
+
+            if ((temp = pl.removeParameter("handspec")) != null) {
+                handspec = temp;
+            }
+        }
+//Mahit end
         if ((temp = pl.removeParameter("title")) != null) {
             this.title = temp.trim();
         }
@@ -709,6 +747,12 @@ public abstract class MHNPattern extends Pattern {
         if (bps <= 0.0)       // signal that we should calculate bps
             bps = calcBps();
 
+//Mahit begin
+//        if (hss != null) {
+//        	bps *= result.getNumberOfJugglers();
+//        }
+//Mahit end
+        
         int balls = getNumberOfPaths();
         int props = (color == null) ? 1 : Math.min(balls, color.length);
         for (int i = 0; i < props; i++) {
@@ -1060,6 +1104,12 @@ public abstract class MHNPattern extends Pattern {
                             lastcatchtime = ((double)k - 0.5*dwell) / bps;
                         else
                             lastcatchtime = ((double)k - dwell) / bps;
+
+//Mahit begin
+                        if (hss != null && dwellmax) {
+                        	lastcatchtime = ((double)k - dwellarray[k]) / bps;
+                        }
+//Mahit end                        
                         ev.setT(lastcatchtime);
 
                         // set the event juggler and hand

--- a/source/jugglinglab/notation/MHNPattern.java
+++ b/source/jugglinglab/notation/MHNPattern.java
@@ -213,9 +213,13 @@ public abstract class MHNPattern extends Pattern {
         if ((temp = pl.removeParameter("title")) != null) {
             this.title = temp.trim();
         }
-
+//Mahit begin
+        if (hss != null) {
+        	this.title = "oss: " + pattern + " ; hss: " + hss;
+        }
         return this;
     }
+//Mahit end
 
     @Override
     public String toString() {
@@ -1016,7 +1020,18 @@ public abstract class MHNPattern extends Pattern {
                         throwtime = ((double)k - 0.25*dwell) / bps;
                     else
                         throwtime = (double)k / bps;
+
+//Mahit begin
+                    if (hss != null) {
+//                    	if (onethrown)
+//                    		throwtime = ((double)k - 0.25*(double)dwellarray[k]) / bps;
+//                    	else
+                    		throwtime = (double)k / bps;
+                    }
+//Mahit end                        
+                    
                     ev.setT(throwtime);
+
 
                     // set the event juggler and hand
                     ev.setHand(j+1, (h==MHNPattern.RIGHT_HAND ? HandLink.RIGHT_HAND : HandLink.LEFT_HAND));
@@ -1106,8 +1121,18 @@ public abstract class MHNPattern extends Pattern {
                             lastcatchtime = ((double)k - dwell) / bps;
 
 //Mahit begin
-                        if (hss != null && dwellmax) {
-                        	lastcatchtime = ((double)k - dwellarray[k]) / bps;
+                        int newk = 0;
+                        if (hss != null) {
+                        	//if getPeriod() > size of dwellarray due to repeats
+                        	//to account for hand/body positions, then reuse
+                        	//dwellarray timings from prior array elements
+                        	if (k >= dwellarray.length) {
+                        		newk = k % dwellarray.length;
+                        	} else {
+                        		newk = k;
+                        	}
+
+                        	lastcatchtime = ((double)k - dwellarray[newk]) / bps;
                         }
 //Mahit end                        
                         ev.setT(lastcatchtime);
@@ -1171,6 +1196,21 @@ public abstract class MHNPattern extends Pattern {
                                 else
                                     catchtime = ((double)k - dwell + ((double)sst2.catchnum/(double)(num_catches-1) - 0.5) *
                                                  splitcatchfactor) / bps;
+//Mahit begin
+                                int newk;
+                                if (hss != null) {
+                                	//if getPeriod() > size of dwellarray due to repeats
+                                	//to account for hand/body positions, then reuse
+                                	//dwellarray timings from prior array elements
+                                	if (k >= dwellarray.length) {
+                                		newk = k % dwellarray.length;
+                                	} else {
+                                		newk = k;
+                                	}
+                                	catchtime = ((double)k - dwellarray[newk] + ((double)sst2.catchnum/(double)(num_catches-1) - 0.5) *
+                                            splitcatchfactor) / bps;
+                                }
+//Mahit end                        
                                 ev.setT(catchtime);
 
                                 if (sst.catchnum == (num_catches - 1))
@@ -1244,11 +1284,22 @@ public abstract class MHNPattern extends Pattern {
                                     nextcatchtime = ((double)tempk - 0.5*dwell) / bps;
                                 else
                                     nextcatchtime = ((double)tempk - dwell) / bps;
+//Mahit begin
+                                if (hss != null) {
+//                                	nextcatchtime = ((double)tempk - dwellarray[tempk]) / bps;
+                                }
+//Mahit end                        
                             } else {
                                 if (next_onecaught)
                                     nextcatchtime = ((double)tempk - 0.5*dwell - 0.5*splitcatchfactor) / bps;
                                 else
                                     nextcatchtime = ((double)tempk - dwell - 0.5*splitcatchfactor) / bps;
+//Mahit begin
+                                if (hss != null) {
+//                                	nextcatchtime = ((double)tempk - dwellarray[tempk]  - 0.5*splitcatchfactor)  / bps;
+                                }
+//Mahit end                        
+
                             }
                             break;
                         }

--- a/source/jugglinglab/notation/SiteswapPattern.java
+++ b/source/jugglinglab/notation/SiteswapPattern.java
@@ -50,6 +50,7 @@ public class SiteswapPattern extends MHNPattern {
         if (hss != null) {
           modParms modinfo = HSS.processHSS(pattern, hss, hold, dwellmax, handspec, dwell);
           pattern = modinfo.convertedPattern;
+//          title = pattern;
           dwellarray = modinfo.dwellBeatsArray;
 //          dwellarray[0] = 0;
         }

--- a/source/jugglinglab/notation/SiteswapPattern.java
+++ b/source/jugglinglab/notation/SiteswapPattern.java
@@ -46,15 +46,14 @@ public class SiteswapPattern extends MHNPattern {
 
         super.fromParameters(pl);
         
-//Mahit Begin
+//hss Begin
         if (hss != null) {
           modParms modinfo = HSS.processHSS(pattern, hss, hold, dwellmax, handspec, dwell);
           pattern = modinfo.convertedPattern;
 //          title = pattern;
           dwellarray = modinfo.dwellBeatsArray;
-//          dwellarray[0] = 0;
         }
-//Mahit End
+//hss End
 
         // pattern = JLFunc.expandRepeats(pattern);
         parseSiteswapNotation();

--- a/source/jugglinglab/notation/SiteswapPattern.java
+++ b/source/jugglinglab/notation/SiteswapPattern.java
@@ -45,6 +45,15 @@ public class SiteswapPattern extends MHNPattern {
             System.out.println("Starting siteswap parser...");
 
         super.fromParameters(pl);
+        
+//Mahit Begin
+        if (hss != null) {
+          modParms modinfo = HSS.processHSS(pattern, hss, hold, dwellmax, handspec, dwell);
+          pattern = modinfo.convertedPattern;
+          dwellarray = modinfo.dwellBeatsArray;
+//          dwellarray[0] = 0;
+        }
+//Mahit End
 
         // pattern = JLFunc.expandRepeats(pattern);
         parseSiteswapNotation();


### PR DESCRIPTION
Implementation of 'hand siteswaps' which enables representation of ALL asynchronous patterns with vanilla siteswap notation. For example 'galloped patterns' or 'hurries' and Prechac patterns with fractional throws do not need any new notation. The math also remains simple in terms of not having to deal with new notation, alphabetical modifiers, etc. A powerful feature this enables is to play around with different combinations of object and hand siteswaps to create and visualize new patterns, including passing patterns which can challenge jugglers at vastly different skill levels with the same pattern.

Feature comprehends multiplex throws and bounce throws also.

Please see attached slides for additional details.
[HandSiteswapFeature.pdf](https://github.com/jkboyce/jugglinglab/files/7083388/HandSiteswapFeature.pdf)
