### PR TITLE
(Debian) Fix exec command in "Juggling Lab.desktop"

### DIFF
--- a/bin/packaging/debian/Juggling Lab.desktop
+++ b/bin/packaging/debian/Juggling Lab.desktop
@@ -2,7 +2,7 @@
 Version=1.0
 Name=Juggling Lab
 Comment=Juggling Lab juggling animator
-Exec=/opt/juggling-lab/bin/Juggling\ Lab
+Exec="/opt/juggling-lab/bin/Juggling Lab"
 Icon=/opt/juggling-lab/lib/Juggling_Lab.png
 Terminal=false
 Type=Application


### PR DESCRIPTION
As the title states.

Upon installing the latest stable release .deb file on my system, I realized it threw an error when trying to launch it through the "Start Menu" (or whatever it's called on linux...). And then I realized the issue was as simple as a bad startup command, and I fixed it by editing the launcher in the manner shown here in this PR.

Please feel free to edit this PR if there are any issues.