### PR TITLE
Add local.properties from Android Studio to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 .kotlin/
 admin/
 build/
+local.properties


### PR DESCRIPTION
I opened the project in Android Studio to have a look around, and it created a file at the root of the repo called local.properties containing the following:

```
## This file must *NOT* be checked into Version Control Systems,
# as it contains information specific to your local configuration.
#
# Location of the SDK. This is only used by Gradle.
# For customization when using a Version Control System, please read the
# header note.
#Sun Jan 04 12:39:00 EST 2026
sdk.dir=/Users/zev/Library/Android/sdk
```

I don't know if I'm doing something differently from other contributors to the project, and I'm an iOS developer so I don't know much about Android Studio or Kotlin, so please excuse the intrusion if this is not the right way to handle this.